### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # slides-react-lyonjs
 
-Pour voir les slides, il faut lancer : 
+Pour voir les slides, il faut lancer :
 
-- npm run hot-dev-server
-- npm run start-dev
+- `npm install`
+- `npm run-script build`
+- `npm run-script hot-dev-server`
+- `npm run-script start-dev`
+
+Puis [http://localhost:9090](http://localhost:9090)

--- a/app/Application/style.css
+++ b/app/Application/style.css
@@ -5,7 +5,7 @@
 
 @font-face {
 	font-family: title-font;
-	src: url(fonts/Cabin-bold.ttf);
+	src: url(fonts/Cabin-Bold.ttf);
 }
 
 


### PR DESCRIPTION
J'ai rencontré quelques coquilles pour visualiser les slides, notamment une typo dans le nom d'une police et j'ai toujours une erreur (non-bloquante) au build:

```
ERROR in Entry module not found: Error: Cannot resolve 'file' or 'directory' ./config/prerender in ~/slides-react-lyonjs
```

Cette PR essaie d'éviter à de futurs lecteurs de rencontrer les mêmes soucis.

Merci d'avoir partagé :wink: 
